### PR TITLE
AbstractCondition introduced to reduce boilerplate

### DIFF
--- a/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/Conditions.java
+++ b/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/Conditions.java
@@ -9,15 +9,10 @@ import java.util.List;
  */
 public class Conditions {
     
-    public static class Always<C> implements Condition<C> {
+    public static class Always<C> extends AbstractCondition<C> {
         @Override
         public boolean isSatisfied(C context) {
             return true;
-        }
-
-        @Override
-        public String name() {
-            return "_Always";
         }
     }
     
@@ -25,15 +20,10 @@ public class Conditions {
         return new Always<C>();
     }
     
-    public static class Never<C> implements Condition<C> {
+    public static class Never<C> extends AbstractCondition<C> {
         @Override
         public boolean isSatisfied(C context) {
             return false;
-        }
-        
-        @Override
-        public String name() {
-            return "_Never";
         }
     }
     

--- a/squirrel-foundation/src/test/java/org/squirrelframework/foundation/fsm/DeclarativeStateMachineTest.java
+++ b/squirrel-foundation/src/test/java/org/squirrelframework/foundation/fsm/DeclarativeStateMachineTest.java
@@ -73,17 +73,11 @@ public class DeclarativeStateMachineTest extends AbstractStateMachineTest {
         void terminate(Integer context);
     }
 
-    static class ExcellentCondition implements Condition<Integer> {
+    static class ExcellentCondition extends AbstractCondition<Integer> {
         @Override
         public boolean isSatisfied(Integer context) {
             return context!=null && context>80;
         }
-
-        @Override
-        public String name() {
-            return "ExcellentCondition";
-        }
-
     }
 
     @SuppressWarnings("serial")

--- a/squirrel-foundation/src/test/java/org/squirrelframework/foundation/fsm/snake/SnakeController.java
+++ b/squirrel-foundation/src/test/java/org/squirrelframework/foundation/fsm/snake/SnakeController.java
@@ -5,11 +5,7 @@ import java.util.Map;
 import java.util.Random;
 
 import org.squirrelframework.foundation.component.SquirrelProvider;
-import org.squirrelframework.foundation.fsm.Condition;
-import org.squirrelframework.foundation.fsm.DotVisitor;
-import org.squirrelframework.foundation.fsm.HistoryType;
-import org.squirrelframework.foundation.fsm.ImmutableState;
-import org.squirrelframework.foundation.fsm.TransitionType;
+import org.squirrelframework.foundation.fsm.*;
 import org.squirrelframework.foundation.fsm.annotation.State;
 import org.squirrelframework.foundation.fsm.annotation.States;
 import org.squirrelframework.foundation.fsm.annotation.Transit;
@@ -64,7 +60,7 @@ public class SnakeController extends AbstractStateMachine<SnakeController, Snake
 		PRESS_START, TURN_UP, TURN_LEFT, TURN_RIGHT, TURN_DOWN, MOVE_AHEAD, PRESS_PAUSE
 	}
 	
-	public static class ContinueRunningCondition implements Condition<SnakeModel> {
+	public static class ContinueRunningCondition extends AbstractCondition<SnakeModel> {
 		@Override
         public boolean isSatisfied(SnakeModel context) {
 			Point nextPoint = computeNextPoint(context.peekFirst(), context.getDirection());
@@ -72,11 +68,6 @@ public class SnakeController extends AbstractStateMachine<SnakeController, Snake
 					nextPoint.y >= 0 && nextPoint.y < GameConfigure.ROW_COUNT;
 			boolean bodyNotCollapsed = context.getSnakePoints().contains(nextPoint)==false;
 			return insideBorder && bodyNotCollapsed;
-        }
-
-        @Override
-        public String name() {
-            return "ContinueRunningCondition";
         }
 	}
 	


### PR DESCRIPTION
Since last changes introduced name() method in Condition interface, and it will match with name of class implementing condition in 90% of cases, it is cool to have abstract base class that reduces this boilerplate.

WDYT?
