### PR TITLE
Added method to set current state

### DIFF
--- a/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/StateMachine.java
+++ b/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/StateMachine.java
@@ -148,6 +148,8 @@ public interface StateMachine<T extends StateMachine<T, S, E, C>, S, E, C> exten
     Collection<S> getAllStates();
     
     Collection<ImmutableState<T, S, E, C>> getAllRawStates();
+
+    void setCurrentState(S currentState);
     
     /**
      * Dump current state machine data. This operation can only be done when state machine status is 

--- a/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/AbstractStateMachine.java
+++ b/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/AbstractStateMachine.java
@@ -515,6 +515,17 @@ public abstract class AbstractStateMachine<T extends StateMachine<T, S, E, C>, S
         }
     }
 
+    @Override
+    public void setCurrentState(S currentState){
+        writeLock.lock();
+        try {
+            data.write().initialState(currentState);
+            data.write().currentState(null);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
     private void entryAll(ImmutableState<T, S, E, C> origin, StateContext<T, S, E, C> stateContext) {
         Stack<ImmutableState<T, S, E, C>> stack = new Stack<ImmutableState<T, S, E, C>>();
 


### PR DESCRIPTION
I have created a pull request in order to be able to set the current state after the state machine has been created. We needed this feature because we load states from the database and we don't want to build a new state machine with every new state we load.