### PR TITLE
use name() instead of toString() in DotVisitor/SCXMLVisitor to support overrided toString()

### DIFF
--- a/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/AbstractVisitor.java
+++ b/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/AbstractVisitor.java
@@ -4,17 +4,17 @@ import java.io.FileWriter;
 import java.io.IOException;
 
 abstract class AbstractVisitor {
-    
+
     protected final StringBuilder buffer = new StringBuilder();
-    
+
     protected void writeLine(final String msg) {
         buffer.append(msg).append("\n");
     }
-    
+
     protected String quoteName(final String id) {
         return "\"" + id + "\"";
     }
-    
+
     protected void saveFile(final String filename, String content) {
         try {
             FileWriter file = new FileWriter(filename);
@@ -23,5 +23,35 @@ abstract class AbstractVisitor {
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    /**
+     * get enum name instead of toString value
+     *
+     * @param enumObj
+     * @return
+     */
+    protected static String getName(Object enumObj) {
+        String stateValue;
+        if (enumObj.getClass().isEnum()) {
+            try {
+                stateValue = (String)enumObj.getClass().getMethod("name").invoke(enumObj, null);
+            } catch (Throwable e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            stateValue = enumObj.toString();
+        }
+        return stateValue;
+    }
+
+    /**
+     * quote with enum name value
+     *
+     * @param enumObj
+     * @return
+     */
+    protected String quoteEnumName(final Object enumObj) {
+        return quoteName(getName(enumObj));
     }
 }

--- a/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/DotVisitorImpl.java
+++ b/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/DotVisitorImpl.java
@@ -12,11 +12,11 @@ import org.squirrelframework.foundation.fsm.StateMachine;
 class DotVisitorImpl extends AbstractVisitor implements DotVisitor {
 
     protected final StringBuilder transBuf = new StringBuilder();
-    
+
     @Override
     public void visitOnEntry(StateMachine<?, ?, ?, ?> visitable) {
         writeLine("digraph {\ncompound=true;");
-        writeLine("subgraph cluster_StateMachine {\nlabel=\""+visitable.getClass().getName()+"\";");
+        writeLine("subgraph cluster_StateMachine {\nlabel=\"" + visitable.getClass().getName() + "\";");
     }
 
     @Override
@@ -27,22 +27,23 @@ class DotVisitorImpl extends AbstractVisitor implements DotVisitor {
 
     @Override
     public void visitOnEntry(ImmutableState<?, ?, ?, ?> visitable) {
-        String stateId = visitable.getStateId().toString();
-        if(visitable.hasChildStates()) {
-            writeLine("subgraph cluster_"+stateId+" {\nlabel=\""+stateId+"\";");
-            if(visitable.getHistoryType()==HistoryType.DEEP) {
-                writeLine(stateId+"History"+" [label=\"\"];");
-            } else if (visitable.getHistoryType()==HistoryType.SHALLOW) {
-                writeLine(stateId+"History"+" [label=\"\"];");
+        String stateId = getName(visitable.getStateId());
+        String stateLabel = visitable.getStateId().toString();
+        if (visitable.hasChildStates()) {
+            writeLine("subgraph cluster_" + stateId + " {\nlabel=\"" + stateLabel + "\";");
+            if (visitable.getHistoryType() == HistoryType.DEEP) {
+                writeLine(stateId + "History" + " [label=\"\"];");
+            } else if (visitable.getHistoryType() == HistoryType.SHALLOW) {
+                writeLine(stateId + "History" + " [label=\"\"];");
             }
         } else {
-            writeLine(stateId+" [label=\""+stateId+"\"];");
+            writeLine(stateId + " [label=\"" + stateLabel + "\"];");
         }
     }
 
     @Override
     public void visitOnExit(ImmutableState<?, ?, ?, ?> visitable) {
-        if(visitable.hasChildStates()) {
+        if (visitable.hasChildStates()) {
             writeLine("}");
         }
     }
@@ -51,30 +52,31 @@ class DotVisitorImpl extends AbstractVisitor implements DotVisitor {
     public void visitOnEntry(ImmutableTransition<?, ?, ?, ?> visitable) {
         ImmutableState<?, ?, ?, ?> sourceState = visitable.getSourceState();
         ImmutableState<?, ?, ?, ?> targetState = visitable.getTargetState();
-        String sourceStateId = sourceState.getStateId().toString();
-        String targetStateId = targetState.getStateId().toString();
-        boolean sourceIsCluster=sourceState.hasChildStates();
-        boolean targetIsCluster=targetState.hasChildStates();
-        String source=(sourceIsCluster)?"cluster_"+sourceStateId:null;
-        String target=(targetIsCluster)?"cluster_"+targetStateId:null;
-        String realStart=(sourceIsCluster)? getSimpleChildOf(sourceState).getStateId().toString():sourceStateId;
-        String realEnd=(targetIsCluster)? getSimpleChildOf(targetState).getStateId().toString():targetStateId;
+        String sourceStateId = getName(sourceState.getStateId());
+        String targetStateId = getName(targetState.getStateId());
+        boolean sourceIsCluster = sourceState.hasChildStates();
+        boolean targetIsCluster = targetState.hasChildStates();
+        String source = (sourceIsCluster) ? "cluster_" + sourceStateId : null;
+        String target = (targetIsCluster) ? "cluster_" + targetStateId : null;
+        String realStart = (sourceIsCluster) ? getName(getSimpleChildOf(sourceState).getStateId()) : sourceStateId;
+        String realEnd = (targetIsCluster) ? getName(getSimpleChildOf(targetState).getStateId()) : targetStateId;
         String edgeLabel = visitable.getEvent().toString();
-        String ltail=(source!=null)?"ltail=\""+source+"\"":null;
-        String lhead=(target!=null)?"lhead=\""+target+"\"":null;
-        transBuf.append("\n"+realStart+" -> "+realEnd+" ["+((ltail!=null)?ltail+",":"")+((lhead!=null)?lhead+",":"")+" label=\""+edgeLabel+"\"];");
+        String ltail = (source != null) ? "ltail=\"" + source + "\"" : null;
+        String lhead = (target != null) ? "lhead=\"" + target + "\"" : null;
+        transBuf.append(
+            "\n" + realStart + " -> " + realEnd + " [" + ((ltail != null) ? ltail + "," : "") + ((lhead != null) ? lhead
+                + "," : "") + " label=\"" + edgeLabel + "\"];");
     }
-    
+
     public ImmutableState<?, ?, ?, ?> getSimpleChildOf(ImmutableState<?, ?, ?, ?> sourceState) {
-        Queue<ImmutableState<?, ?, ?, ?>> list=new LinkedList<ImmutableState<?, ?, ?, ?>>();
+        Queue<ImmutableState<?, ?, ?, ?>> list = new LinkedList<ImmutableState<?, ?, ?, ?>>();
         list.add(sourceState);
-        while(!list.isEmpty()) {
-            ImmutableState<?, ?, ?, ?> x=list.poll();
-            int l=x.getChildStates().size();
-            for (int i=0; i<l; i++) {
+        while (!list.isEmpty()) {
+            ImmutableState<?, ?, ?, ?> x = list.poll();
+            int l = x.getChildStates().size();
+            for (int i = 0; i < l; i++) {
                 ImmutableState<?, ?, ?, ?> c = x.getChildStates().get(i);
-                if (c.hasChildStates()) list.add(c);
-                else return c;
+                if (c.hasChildStates()) { list.add(c); } else { return c; }
             }
         }
         return sourceState;
@@ -86,7 +88,7 @@ class DotVisitorImpl extends AbstractVisitor implements DotVisitor {
 
     @Override
     public void convertDotFile(String filename) {
-        saveFile(filename+".dot", buffer.toString());
+        saveFile(filename + ".dot", buffer.toString());
     }
 
 }

--- a/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/SCXMLVisitorImpl.java
+++ b/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/SCXMLVisitorImpl.java
@@ -23,7 +23,7 @@ class SCXMLVisitorImpl extends AbstractVisitor implements SCXMLVisitor {
     
     @Override
     public void visitOnEntry(StateMachine<?, ?, ?, ?> visitable) {
-        writeLine("<scxml initial=" + quoteName(visitable.getInitialState().toString()) + " version=\"1.0\" " +
+        writeLine("<scxml initial=" + quoteEnumName(visitable.getInitialState()) + " version=\"1.0\" " +
                 "xmlns=\"http://www.w3.org/2005/07/scxml\" xmlns:sqrl=\"http://squirrelframework.org/squirrel\">");
         writeLine("<sqrl:fsm "+visitable.getDescription()+" />");
     }
@@ -36,14 +36,14 @@ class SCXMLVisitorImpl extends AbstractVisitor implements SCXMLVisitor {
     @Override
     public void visitOnEntry(ImmutableState<?, ?, ?, ?> visitable) {
         if(visitable.isParallelState()) {
-            writeLine("<parallel id= " + quoteName(visitable.toString()) + ">");
+            writeLine("<parallel id= " + quoteEnumName(visitable) + ">");
         } else if(visitable.isFinalState()) {
-            writeLine("<final id= " + quoteName(visitable.toString()) + ">");
+            writeLine("<final id= " + quoteEnumName(visitable) + ">");
         } else { 
             StringBuilder builder = new StringBuilder("<state id= ");
-            builder.append(quoteName(visitable.toString()));
+            builder.append(quoteEnumName(visitable));
             if(visitable.getInitialState()!=null) {
-                builder.append(" initial= ").append(quoteName(visitable.getInitialState().toString()));
+                builder.append(" initial= ").append(quoteEnumName(visitable.getInitialState()));
             }
             builder.append(">");
             writeLine(builder.toString());
@@ -80,10 +80,10 @@ class SCXMLVisitorImpl extends AbstractVisitor implements SCXMLVisitor {
     @Override
     public void visitOnEntry(ImmutableTransition<?, ?, ?, ?> visitable) {
         writeLine("<transition event="
-                + quoteName(visitable.getEvent().toString()) + " sqrl:priority="
+                + quoteEnumName(visitable.getEvent()) + " sqrl:priority="
                 + quoteName(Integer.toString(visitable.getPriority())) + " sqrl:type="
                 + quoteName(visitable.getType().toString()) + " target="
-                + quoteName(visitable.getTargetState().toString()) + " cond="
+                + quoteEnumName(visitable.getTargetState()) + " cond="
                 + quoteName(visitable.getCondition().toString())+">");
         for(Action<?, ?, ?, ?> action : visitable.getActions()) {
             writeAction(action);

--- a/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/StateImpl.java
+++ b/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/StateImpl.java
@@ -532,7 +532,8 @@ class StateImpl<T extends StateMachine<T, S, E, C>, S, E, C> implements MutableS
 
     @Override
     public String toString() {
-        return getStateId().toString();
+        //use enum name value instead of toString result
+        return AbstractVisitor.getName(getStateId());
     }
 
     @Override

--- a/squirrel-foundation/src/test/java/org/squirrelframework/foundation/fsm/HierarchicalStateMachineTest.java
+++ b/squirrel-foundation/src/test/java/org/squirrelframework/foundation/fsm/HierarchicalStateMachineTest.java
@@ -1,6 +1,11 @@
 package org.squirrelframework.foundation.fsm;
 
-import org.junit.*;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.squirrelframework.foundation.component.SquirrelPostProcessorProvider;
 import org.squirrelframework.foundation.component.SquirrelProvider;
 import org.squirrelframework.foundation.fsm.annotation.State;
@@ -16,13 +21,49 @@ import static org.junit.Assert.assertThat;
 public class HierarchicalStateMachineTest {
 
     public enum HState {
-        A, A1, A1a, A1a1, A2, A2a, A3, A4, B, B1, B2, B2a, B3, D, E, E1, C
+        A("this is A"), A1, A1a, A1a1, A2, A2a, A3, A4, B, B1, B2, B2a, B3, D, E, E1, C;
+        private String desc;
+
+        HState() {
+        }
+
+        HState(String desc) {
+            this.desc = desc;
+        }
+
+        public String getDesc() {
+            return desc;
+        }
+
+        @Override
+        public String toString() {
+            if(StringUtils.isNotBlank(desc)){
+                return this.name() + '(' + desc + ')';
+            }else{
+                return this.name();
+            }
+        }
     }
 
     public enum HEvent {
-        A2B, B2A, Finish,
+        A2B("this is A2B"), B2A, Finish,
         A12A2, A12A3, A12A4, A12A1a, A12A1a1, A1a12A1, A1a2A1a1, A1a12A1a, A32A1, A12B3, A22A2a,
-        B12B2, B22B2a, B22A, A2D, D2E1
+        B12B2, B22B2a, B22A, A2D, D2E1;
+        private String desc;
+
+        HEvent() {
+        }
+        HEvent(String desc) {
+            this.desc = desc;
+        }
+        @Override
+        public String toString() {
+            if(StringUtils.isNotBlank(desc)){
+                return this.name() + '(' + desc + ')';
+            }else{
+                return this.name();
+            }
+        }
     }
 
     @States({
@@ -259,7 +300,7 @@ public class HierarchicalStateMachineTest {
 
         public void leftE(HState from, HState to, HEvent event, Integer context) {
             logger.append("leftE");
-        } 
+        }
 
         public void enterE1(HState from, HState to, HEvent event, Integer context) {
             logger.append("enterE1");
@@ -267,7 +308,7 @@ public class HierarchicalStateMachineTest {
 
         public void leftE1(HState from, HState to, HEvent event, Integer context) {
             logger.append("leftE1");
-        } 
+        }
 
         public void transitD2E1(HState from, HState to, HEvent event, Integer context) {
             logger.append("transitD2E1");
@@ -372,11 +413,11 @@ public class HierarchicalStateMachineTest {
         stateMachine.start();
         assertThat(stateMachine.consumeLog(), is(equalTo("entryA.entryA1")));
         assertThat(stateMachine.getCurrentState(), is(equalTo(HState.A1)));
-        
+
         stateMachine.fire(HEvent.A12A2, 1);
         assertThat(stateMachine.consumeLog(), is(equalTo("exitA1.transitFromA1ToA2OnA12A2.entryA2")));
         assertThat(stateMachine.getCurrentState(), is(equalTo(HState.A2)));
-        
+
         testResult = stateMachine.test(HEvent.A2B, 1);
         assertThat(stateMachine.consumeLog(), is(equalTo("")));
         assertThat(testResult, is(equalTo(HState.B1)));
@@ -454,7 +495,7 @@ public class HierarchicalStateMachineTest {
         assertThat(savedData.currentState(), is(equalTo(HState.A1)));
         assertThat(savedData.initialState(), is(equalTo(HState.A)));
         assertThat(savedData.lastState(), is(equalTo(HState.A3)));
-        
+
         assertThat(savedData.lastActiveChildStateOf(HState.A), is(equalTo(HState.A3)));
         setup();
 
@@ -513,25 +554,25 @@ public class HierarchicalStateMachineTest {
     public void testExportAndImportHierarchicalStateMachine() {
         SCXMLVisitor visitor = SquirrelProvider.getInstance().newInstance(SCXMLVisitor.class);
         stateMachine.accept(visitor);
-//        visitor.convertSCXMLFile("HierarchicalStateMachine", true);
+        //visitor.convertSCXMLFile("HierarchicalStateMachine", true);
         String xmlDef = visitor.getScxml(false);
-        
+
         UntypedStateMachineBuilder builder = new UntypedStateMachineImporter().importDefinition(xmlDef);
         stateMachine = builder.newAnyStateMachine(HState.A);
-        
+
         HState testResult = stateMachine.test(HEvent.A12A2, 1);
         assertThat(testResult, is(equalTo(HState.A2)));
         assertThat(stateMachine.consumeLog(), is(equalTo("")));
         assertThat(stateMachine.getStatus(), is(equalTo(StateMachineStatus.INITIALIZED)));
-        
+
         stateMachine.start();
         assertThat(stateMachine.consumeLog(), is(equalTo("entryA.entryA1")));
         assertThat(stateMachine.getCurrentState(), is(equalTo(HState.A1)));
-        
+
         stateMachine.fire(HEvent.A12A2, 1);
         assertThat(stateMachine.consumeLog(), is(equalTo("exitA1.transitFromA1ToA2OnA12A2.entryA2")));
         assertThat(stateMachine.getCurrentState(), is(equalTo(HState.A2)));
-        
+
         testResult = stateMachine.test(HEvent.A2B, 1);
         assertThat(stateMachine.consumeLog(), is(equalTo("")));
         assertThat(testResult, is(equalTo(HState.B1)));


### PR DESCRIPTION
use name() instead of toString() in DotVisitor/SCXMLVisitor to support overrided toString().
This is the graphviz result of using my custom toString function in State/Event enum.
`digraph {`
`compound=true;`
`subgraph cluster_StateMachine {`
`label="com.yit.rma.statemachine.redeliver.RedeliverStateMachine";`
`REDELIVERED_FINISHED [label="REDELIVERED_FINISHED(发货已完成-维权结束)"];`
`PENDING [label="PENDING(新申请-待处理)"];`
`REJECTED [label="REJECTED(审核已驳回-维权结束)"];`
`REDELIVERED_SENDING [label="REDELIVERED_SENDING(审核已通过-发货中)"];`
`CONFIRMING [label="CONFIRMING(申请已处理-待确认)"];`
`PENDING -> CONFIRMING [ label="APPLY_CONFIRM(确认申请)"];`
`REDELIVERED_SENDING -> REDELIVERED_FINISHED [ label="UPLOAD_REDELIVER_WAYBILL(上传发货单)"];`
`CONFIRMING -> REJECTED [ label="REJECT(驳回审核)"];`
`CONFIRMING -> REDELIVERED_SENDING [ label="APPLY_APPROVED(通过审核)"];}}`
![redeliver](https://user-images.githubusercontent.com/4070470/27369896-90064008-568c-11e7-874e-e42d43e3fcf3.jpg)
