### PR TITLE
优化状态机error日志的打印

### DIFF
--- a/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/AbstractExecutionService.java
+++ b/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/AbstractExecutionService.java
@@ -81,7 +81,8 @@ public abstract class AbstractExecutionService<T extends StateMachine<T, S, E, C
                         actionContext.run();
                     }
                 } catch (Exception e) {
-                    logger.error("Error during transition", e);
+                    // 此处不应该打印Error日志，应该将异常交给调用者来决定是否打印异常。
+                    //logger.error("Error during transition", e);
                     Throwable t = (e instanceof SquirrelRuntimeException) ?
                             ((SquirrelRuntimeException)e).getTargetException() : e;
                     // wrap any exception into transition exception


### PR DESCRIPTION
此处不应该打印Error日志，应该将异常交给调用者来决定是否打印异常。
因为有可能在状态机中抛出的是业务异常，不需要进行ERROR级别的记录。