### PR TITLE
support default initial state

### DIFF
--- a/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/StateMachineBuilder.java
+++ b/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/StateMachineBuilder.java
@@ -205,6 +205,11 @@ public interface StateMachineBuilder<T extends StateMachine<T, S, E, C>, S, E, C
      * @param terminateEvent
      */
     void defineTerminateEvent(E terminateEvent);
+
+    /**
+     * Define default initial state for state machine started
+     */
+    void defineDefaultInitialState(S stateId);
     
     /**
      * Define on entry actions for state
@@ -222,14 +227,14 @@ public interface StateMachineBuilder<T extends StateMachine<T, S, E, C>, S, E, C
     
     /**
      * Create a new state machine instance
-     * @param initialStateId initial state id
+     * @param initialStateId initial state id, null means using the default
      * @return new state machine instance
      */
     T newStateMachine(S initialStateId);
     
     /**
      * Create new state machine instance according to state machine definition 
-     * @param initialStateId the id of state machine initial state
+     * @param initialStateId the id of state machine initial state, null means using the default
      * @param extraParams other parameters for instantiate state machine
      * @return new state machine
      */
@@ -237,7 +242,7 @@ public interface StateMachineBuilder<T extends StateMachine<T, S, E, C>, S, E, C
     
     /**
      * Create new state machine instance according to state machine definition
-     * @param initialStateId the id of state machine initial state
+     * @param initialStateId the id of state machine initial state, null means using the default
      * @param configuration configuration for state machine
      * @param extraParams other parameters for instantiate state machine
      * @return new state machine

--- a/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/StateMachineBuilderImpl.java
+++ b/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/StateMachineBuilderImpl.java
@@ -62,6 +62,8 @@ public class StateMachineBuilderImpl<T extends StateMachine<T, S, E, C>, S, E, C
     private final MvelScriptManager scriptManager;
     
     private E startEvent, finishEvent, terminateEvent;
+
+    private S defaultInitStateId;
     
     private final ExecutionContext executionContext;
     
@@ -701,6 +703,7 @@ public class StateMachineBuilderImpl<T extends StateMachine<T, S, E, C>, S, E, C
     @Override
     public T newStateMachine(S initialStateId, StateMachineConfiguration configuration, Object... extraParams) {
         if(!prepared) prepare();
+        if (initialStateId == null) initialStateId = defaultInitStateId;
         if(!isValidState(initialStateId)) {
             throw new IllegalArgumentException(getClass()+" cannot find Initial state \'"+ 
                     initialStateId+"\' in state machine.");
@@ -922,6 +925,12 @@ public class StateMachineBuilderImpl<T extends StateMachine<T, S, E, C>, S, E, C
     public void defineTerminateEvent(E terminateEvent) {
         checkState();
         this.terminateEvent = terminateEvent;
+    }
+
+    @Override
+    public void defineDefaultInitialState(S stateId) {
+        checkState();
+        this.defaultInitStateId = stateId;
     }
     
     void setScanAnnotations(boolean isScanAnnotations) {

--- a/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/StateMachineImporterImpl.java
+++ b/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/StateMachineImporterImpl.java
@@ -61,7 +61,9 @@ public class StateMachineImporterImpl<T extends StateMachine<T, S, E, C>, S, E, 
             ArrayListMultimap.create();
     
     protected Boolean isEntryAction;
-    
+
+    protected String initStateIdName;
+
     protected final Map<String, Object> reusableInstance = Maps.newHashMap();
     
     public StateMachineImporterImpl() {
@@ -138,6 +140,8 @@ public class StateMachineImporterImpl<T extends StateMachine<T, S, E, C>, S, E, 
             
             currentStates.clear();
             currentTranstionBuilder=null;
+
+            stateMachineBuilder.defineDefaultInitialState(stateConverter.convertFromString(initStateIdName));
         } else if(qName.equals("state") || qName.equals("final") || qName.equals("parallel")) {
             MutableState<T, S, E, C> parentState = null;
             if(currentStates.size()>0) {
@@ -252,6 +256,8 @@ public class StateMachineImporterImpl<T extends StateMachine<T, S, E, C>, S, E, 
             } else if(condSchema.equals("mvel")) {
                 getCurrentTranstionBuilder().whenMvel(condContent);
             }
+        } else if (qName.equals("scxml")) {
+            this.initStateIdName = attributes.getValue("initial");
         }
     }
     

--- a/squirrel-foundation/src/test/java/org/squirrelframework/foundation/fsm/DefaultInitialStateTest.java
+++ b/squirrel-foundation/src/test/java/org/squirrelframework/foundation/fsm/DefaultInitialStateTest.java
@@ -1,0 +1,47 @@
+package org.squirrelframework.foundation.fsm;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.squirrelframework.foundation.fsm.impl.AbstractStateMachine;
+
+public class DefaultInitialStateTest {
+    private StateMachineBuilder<DefaultInitialStateMachine, TestState, TestEvent, Void> builder;
+
+    @Before
+    public void setUp() throws Exception {
+        builder = StateMachineBuilderFactory.create(DefaultInitialStateMachine.class, TestState.class, TestEvent.class, Void.class);
+        builder.defineDefaultInitialState(TestState.A);
+        builder.transition().from(TestState.A).to(TestState.B).on(TestEvent.ToB);
+        builder.transition().from(TestState.B).to(TestState.C).on(TestEvent.ToC);
+    }
+
+    @Test
+    public void defineInitialState() {
+        // define the initial state by builder.newStateMachine
+        DefaultInitialStateMachine initWithA = builder.newStateMachine(TestState.A);
+        Assert.assertEquals(TestState.A, initWithA.getInitialState());
+        initWithA.fire(TestEvent.ToB);
+        Assert.assertEquals(TestState.B, initWithA.getCurrentState());
+
+        // define the initial state by builder.defineInitialStateId
+        DefaultInitialStateMachine initWithDefault = builder.newStateMachine(null);
+        Assert.assertEquals(TestState.A, initWithDefault.getInitialState());
+        initWithDefault.fire(TestEvent.ToB);
+        Assert.assertEquals(TestState.B, initWithDefault.getCurrentState());
+    }
+
+    @Test
+    public void exportAndImport() {
+        DefaultInitialStateMachine stateMachine = builder.newStateMachine(null);
+        String sqrlScxml = stateMachine.exportXMLDefinition(true);
+        System.out.println(sqrlScxml);
+
+        UntypedStateMachineBuilder builder = new UntypedStateMachineImporter().importDefinition(sqrlScxml);
+        DefaultInitialStateMachine recover = builder.newAnyStateMachine(null);
+        Assert.assertEquals(TestState.A, recover.getInitialState());
+    }
+
+    static class DefaultInitialStateMachine extends AbstractStateMachine<DefaultInitialStateMachine, TestState, TestEvent, Void> {
+    }
+}


### PR DESCRIPTION
According to the SCXML standard, the initial state of the state machine is optional. Since the exported data contains the initial state, we can also support the definition of the initial state when building the state machine.