### PR TITLE
修复 processEvents 中可能因为并发执行导致 event 未及时处理问题

### DIFF
--- a/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/AbstractStateMachine.java
+++ b/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/AbstractStateMachine.java
@@ -202,7 +202,7 @@ public abstract class AbstractStateMachine<T extends StateMachine<T, S, E, C>, S
     }
     
     private void processEvents() {
-        if (isIdle()) {
+        while (isIdle() && queuedEvents.size() > 0) {
             writeLock.lock();
             setStatus(StateMachineStatus.BUSY);
             try {


### PR DESCRIPTION
fix issue 
#137 

修改后的效果是每当线程离开 processEvents 方法时，必须保证 queuedEvents 队列被清空，从而避免有消息未处理