### PR TITLE
Fix NullPointerException when logging an MVEL action failure (#67)

### DIFF
--- a/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/MvelActionImpl.java
+++ b/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/MvelActionImpl.java
@@ -51,7 +51,7 @@ class MvelActionImpl<T extends StateMachine<T, S, E, C>, S, E, C> implements Act
             variables.put(MvelScriptManager.VAR_STATE_MACHINE, stateMachine);
             scriptManager.eval(mvelExpression, variables, Void.class);
         } catch (RuntimeException e) {
-            logger.error("Evaluate \""+mvelExpression+"\" failed, which caused by "+e.getCause().getMessage());
+            logger.error("Evaluate \""+mvelExpression+"\" failed with "+e.getMessage()+(e.getCause()!=null ? ", which caused by "+e.getCause().getMessage() : ""));
             throw e;
         }
     }

--- a/squirrel-foundation/src/test/java/org/squirrelframework/foundation/fsm/impl/MvelActionImplTest.java
+++ b/squirrel-foundation/src/test/java/org/squirrelframework/foundation/fsm/impl/MvelActionImplTest.java
@@ -1,0 +1,45 @@
+package org.squirrelframework.foundation.fsm.impl;
+
+import org.junit.Test;
+import org.squirrelframework.foundation.fsm.MvelScriptManager;
+
+/**
+ * Issue #67: when an MVEL action fails with a RuntimeException that has no
+ * cause, the failure-logging branch in {@link MvelActionImpl#execute} must not
+ * itself throw a NullPointerException. The original RuntimeException must be
+ * the exception that propagates out.
+ */
+public class MvelActionImplTest {
+
+    private static class CauselessFailureScriptManager implements MvelScriptManager {
+        @Override
+        public <T> T eval(String script, Object context, Class<T> returnType) {
+            throw new RuntimeException("mvel failed");
+        }
+
+        @Override
+        public void compile(String script) {
+        }
+
+        @Override
+        public boolean evalBoolean(String script, Object context) {
+            return false;
+        }
+    }
+
+    @Test
+    public void executeShouldRethrowOriginalExceptionWhenCauseIsNull() {
+        ExecutionContext executionContext =
+                new ExecutionContext(new CauselessFailureScriptManager(), Object.class, new Class<?>[0]);
+        MvelActionImpl<?, ?, ?, ?> action = new MvelActionImpl<>("noop:::1 > 0", executionContext);
+
+        try {
+            action.execute(null, null, null, null, null);
+        } catch (NullPointerException npe) {
+            throw new AssertionError("failure logging threw NullPointerException instead of " +
+                    "rethrowing the original RuntimeException", npe);
+        } catch (RuntimeException expected) {
+            // Original MVEL failure is expected to propagate unchanged.
+        }
+    }
+}


### PR DESCRIPTION
## Summary
`MvelActionImpl` logged action failures with `e.getCause().getMessage()`. When the caught `RuntimeException` had no cause, this threw a `NullPointerException` inside the catch block, masking the original error.

This applies the same null-safe logging already used by `MvelConditionImpl`.

Fixes #67.

## Test plan
- [x] Added `MvelActionImplTest` - verified to fail on the original code and pass with the fix.
- [x] Full suite passes (157 tests, JDK 8).