### PR TITLE
Make canAccept consider events handled by parent states (#128)

### DIFF
--- a/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/AbstractStateMachine.java
+++ b/squirrel-foundation/src/main/java/org/squirrelframework/foundation/fsm/impl/AbstractStateMachine.java
@@ -381,9 +381,20 @@ public abstract class AbstractStateMachine<T extends StateMachine<T, S, E, C>, S
                 return false;
             }
         }
-        return testRawState.getAcceptableEvents().contains(event);
+        // an event declined by the current state is delegated to its parent
+        // state by internalFire, so canAccept must walk up the same chain
+        for(ImmutableState<T, S, E, C> state=testRawState; state!=null; state=state.getParentState()) {
+            if(state.getAcceptableEvents().contains(event)) {
+                return true;
+            }
+            if(state.getParentState()!=null &&
+                    (state.getParentState().isRegion() || state.getParentState().isParallelState())) {
+                break;
+            }
+        }
+        return false;
     }
-    
+
     protected boolean isIdle() {
         return getStatus()!=StateMachineStatus.BUSY;
     }

--- a/squirrel-foundation/src/test/java/org/squirrelframework/foundation/issues/Issue128.java
+++ b/squirrel-foundation/src/test/java/org/squirrelframework/foundation/issues/Issue128.java
@@ -1,0 +1,48 @@
+package org.squirrelframework.foundation.issues;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.squirrelframework.foundation.fsm.StateMachineBuilderFactory;
+import org.squirrelframework.foundation.fsm.UntypedStateMachineBuilder;
+import org.squirrelframework.foundation.fsm.annotation.ContextInsensitive;
+import org.squirrelframework.foundation.fsm.annotation.StateMachineParameters;
+import org.squirrelframework.foundation.fsm.impl.AbstractUntypedStateMachine;
+
+/**
+ * Issue #128: when the state machine is in a nested state, canAccept must
+ * return true for events handled by a transition defined on an ancestor
+ * state, because internalFire delegates declined events up the parent chain.
+ */
+public class Issue128 {
+
+    enum Issue128State {A, A1, A2}
+
+    enum Issue128Event {PARENT_EVENT, CHILD_EVENT, UNKNOWN}
+
+    @ContextInsensitive
+    @StateMachineParameters(stateType = Issue128State.class, eventType = Issue128Event.class, contextType = Void.class)
+    static class Issue128StateMachine extends AbstractUntypedStateMachine {
+    }
+
+    private Issue128StateMachine buildMachine() {
+        UntypedStateMachineBuilder builder = StateMachineBuilderFactory.create(Issue128StateMachine.class);
+        builder.defineSequentialStatesOn(Issue128State.A, Issue128State.A1, Issue128State.A2);
+        builder.internalTransition().within(Issue128State.A).on(Issue128Event.PARENT_EVENT);
+        builder.localTransition().from(Issue128State.A1).to(Issue128State.A2).on(Issue128Event.CHILD_EVENT);
+        return builder.newUntypedStateMachine(Issue128State.A);
+    }
+
+    @Test
+    public void canAcceptShouldFindEventHandledByParentStateWhileInChildState() {
+        Issue128StateMachine fsm = buildMachine();
+        fsm.start();
+        Assert.assertEquals(Issue128State.A1, fsm.getCurrentState());
+
+        Assert.assertTrue("event handled by child state must be acceptable",
+                fsm.canAccept(Issue128Event.CHILD_EVENT));
+        Assert.assertTrue("event handled by parent state must be acceptable while in child state",
+                fsm.canAccept(Issue128Event.PARENT_EVENT));
+        Assert.assertFalse("unknown event must not be acceptable",
+                fsm.canAccept(Issue128Event.UNKNOWN));
+    }
+}


### PR DESCRIPTION
## Summary
While in a nested state, `AbstractStateMachine.canAccept` only checked the current state's own acceptable events, returning `false` for events handled by an ancestor state - even though `internalFire` delegates declined events up the parent chain.

This walks the parent chain in `canAccept`, applying the same region / parallel-state boundary that `internalFire` uses.

Fixes #128.

## Test plan
- [x] Added `Issue128` test - verified to fail on the original code and pass with the fix.
- [x] Full suite passes (155 tests, JDK 8).